### PR TITLE
Support to construct Task steps

### DIFF
--- a/fluid.py
+++ b/fluid.py
@@ -29,20 +29,18 @@ def task(func):
     return print_taskrun
 
 
-STEPS = []  # For holding steps of a Task.
-
-
 def step(image, cmd, args):
-    '''Append a step to global variable STEPS'''
+    '''Define a step'''
 
     def step_name():
         '''step_name is only supposed to be called by step'''
         # See https://stackoverflow.com/a/6628348/724872.
+        # frame 0 - step_name()
+        # frame 1 - add_step()
+        # frame 2 - fluid.step()
         caller_of_step = inspect.stack()[2]
         filename = caller_of_step[1]
         lineno = caller_of_step[2]
         return k8s.safe_name(f"{filename}-{lineno}")
 
-    global STEPS
-    STEPS.append(
-        tekton.step(step_name(), image, cmd, args))
+    tekton.add_step(step_name(), image, cmd, args)

--- a/tekton.py
+++ b/tekton.py
@@ -16,7 +16,8 @@ def task(func):
         spec={
             "inputs": {
                 "params": task_params(inspect.getfullargspec(func))
-            }
+            },
+            "steps": task_steps(func)
         })
 
 
@@ -87,11 +88,28 @@ def task_run_param(arg_name, arg_value):
     }
 
 
-def step(name, image, cmd, args):
-    '''Return a step'''
-    return {
+STEPS = []  # For holding steps of a Task.
+
+
+def task_steps(func):
+    '''Call func with fake parameters to trace STEPS'''
+    argspec = inspect.getfullargspec(func)
+    fake_args = []
+    for arg in argspec.args:
+        fake_args.append(f"$(inputs.params.{arg})")
+
+    global STEPS
+    STEPS = []
+    func(*fake_args)
+    return STEPS
+
+
+def add_step(name, image, cmd, args):
+    '''Append a step definition to STEPS'''
+    global STEPS
+    STEPS.append({
         "name": name,
         "image": image,
         "command": cmd,
         "args": args
-    }
+    })


### PR DESCRIPTION
How Fluid users define steps.

- In a Fluid function, say, `func`, each call to `fluid.step` defines a step.
- `fluid.step` calls `tekton.add_step` to append the step definition to global variable `tekton.STEPS`.

How Fluid retrieve step definitions in a Task.

- `tekton.task(func)` calls `tekton.task_steps(func)` to get the step definition list of `func`.
- `tekton.task_steps` insepct `func` and construct a fake parameter list `fake_args`, where each element is a string of the form `$(inputs.params.<param_name>)`.
- `tekton.task_steps` calls `func` with `*fake_args`.  Each fake arg goes to a call to `fluid.step` and will appear in `tekton.STEPS`.
- `tekton.task_steps` returns `tekton.STEPS` to `tekton.task`.